### PR TITLE
fix: favicon not loading on github pages

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,7 +16,7 @@ const geistMono = localFont({
 export const metadata: Metadata = {
   title: "Greenhouse",
   description: "Educational codespaces",
-  icons: [{ rel: "icon", url: "/favicon.ico" }],
+  icons: [{ rel: "icon", url: "favicon.ico" }],
 };
 
 export default function RootLayout({


### PR DESCRIPTION
Since the site is deployed to the subpath /site on https://thegreenhouseproject.github.io/site/ when I loaded the favicon from the root on #38, the favicon was failing to load as it was loading the icon from https://thegreenhouseproject.github.io/favicon.ico instead of https://thegreenhouseproject.github.io/site/favicon.ico.  This *should* fix that as it is a relative link but I'm not certain. 